### PR TITLE
Update stochastic_process.py

### DIFF
--- a/RAMP_v02-pre/initialise.py
+++ b/RAMP_v02-pre/initialise.py
@@ -48,7 +48,7 @@ def Initialise_inputs(j):
     '''
     peak_enlarg = 0 #percentage random enlargement or reduction of peak time range length
     mu_peak = 0.5 #median value of gaussian distribution [0,1] by which the number of coincident switch_ons is randomly selected
-    s_peak = 1 #standard deviation (as percentage of the median value) of the gaussian distribution [0,1] above mentioned
+    s_peak = 0.5 #standard deviation (as percentage of the median value) of the gaussian distribution [0,1] above mentioned
     op_factor = 0.5 #off-peak coincidence calculation parameter
 
     return (peak_enlarg, mu_peak, s_peak, op_factor, Year_behaviour, user_list)

--- a/RAMP_v02-pre/initialise.py
+++ b/RAMP_v02-pre/initialise.py
@@ -49,6 +49,7 @@ def Initialise_inputs(j):
     peak_enlarg = 0 #percentage random enlargement or reduction of peak time range length
     mu_peak = 0.5 #median value of gaussian distribution [0,1] by which the number of coincident switch_ons is randomly selected
     s_peak = 1 #standard deviation (as percentage of the median value) of the gaussian distribution [0,1] above mentioned
+    op_factor = 0.5 #off-peak coincidence calculation parameter
 
-    return (peak_enlarg, mu_peak, s_peak, Year_behaviour, user_list)
+    return (peak_enlarg, mu_peak, s_peak, op_factor, Year_behaviour, user_list)
 

--- a/RAMP_v02-pre/stochastic_process.py
+++ b/RAMP_v02-pre/stochastic_process.py
@@ -205,9 +205,9 @@ def Stochastic_Process(j):
                                 if tot_time > rand_time: #control to check when the total functioning time is reached. It will be typically overcome, so a correction is applied to avoid this
                                     indexes_adj = indexes[:-(tot_time-rand_time)] #correctes indexes size to avoid overcoming total time
                                     if np.in1d(peak_time_range,indexes_adj).any() and App.fixed == 'no': #check if indexes are in peak window and if the coincident behaviour is locked by the "fixed" attribute
-                                        coincidence = min(App.number,max(1,math.ceil(random.gauss(math.ceil(App.number*mu_peak),(s_peak*App.number*mu_peak))))) #calculates coincident behaviour within the peak time range
+                                        coincidence = min(App.number,max(1,math.ceil(random.gauss((App.number*mu_peak+0.5),(s_peak*App.number*mu_peak))))) #calculates coincident behaviour within the peak time range
                                     elif np.in1d(peak_time_range,indexes_adj).any()== False and App.fixed == 'no': #check if indexes are off-peak and if coincident behaviour is locked or not
-                                        Prob = random.uniform(0,(App.number-1)/App.number) #calculates probability of coincident switch_ons off-peak
+                                        Prob = random.uniform(0,(App.number-0.5)/App.number) #calculates probability of coincident switch_ons off-peak
                                         array = np.arange(0,App.number)/App.number
                                         try:
                                             on_number = np.max(np.where(Prob>=array))+1
@@ -239,9 +239,9 @@ def Stochastic_Process(j):
                                     break #exit cycle and go to next App
                                 else: #if the tot_time has not yet exceeded the App total functioning time, the cycle does the same without applying corrections to indexes size
                                     if np.in1d(peak_time_range,indexes).any() and App.fixed == 'no':
-                                        coincidence = min(App.number,max(1,math.ceil(random.gauss(math.ceil(App.number*mu_peak),(s_peak*App.number*mu_peak)))))
+                                        coincidence = min(App.number,max(1,math.ceil(random.gauss((App.number*mu_peak+0.5),(s_peak*App.number*mu_peak)))))
                                     elif np.in1d(peak_time_range,indexes).any() == False and App.fixed == 'no':
-                                        Prob = random.uniform(0,(App.number-1)/App.number)
+                                        Prob = random.uniform(0,(App.number-0.5)/App.number)
                                         array = np.arange(0,App.number)/App.number
                                         try:
                                             on_number = np.max(np.where(Prob>=array))+1

--- a/RAMP_v02-pre/stochastic_process.py
+++ b/RAMP_v02-pre/stochastic_process.py
@@ -11,7 +11,7 @@ from initialise import Initialise_model, Initialise_inputs
 
 def Stochastic_Process(j):
     Profile, num_profiles = Initialise_model()
-    peak_enlarg, mu_peak, s_peak, Year_behaviour, User_list = Initialise_inputs(j)
+    peak_enlarg, mu_peak, s_peak, op_factor, Year_behaviour, User_list = Initialise_inputs(j)
     '''
     Calculation of the peak time range, which is used to discriminate between off-peak and on-peak coincident switch-on probability
     Calculates first the overall Peak Window (taking into account all User classes). 
@@ -207,7 +207,7 @@ def Stochastic_Process(j):
                                     if np.in1d(peak_time_range,indexes_adj).any() and App.fixed == 'no': #check if indexes are in peak window and if the coincident behaviour is locked by the "fixed" attribute
                                         coincidence = min(App.number,max(1,math.ceil(random.gauss((App.number*mu_peak+0.5),(s_peak*App.number*mu_peak))))) #calculates coincident behaviour within the peak time range
                                     elif np.in1d(peak_time_range,indexes_adj).any()== False and App.fixed == 'no': #check if indexes are off-peak and if coincident behaviour is locked or not
-                                        Prob = random.uniform(0,(App.number-0.5)/App.number) #calculates probability of coincident switch_ons off-peak
+                                        Prob = random.uniform(0,(App.number-op_factor)/App.number) #calculates probability of coincident switch_ons off-peak
                                         array = np.arange(0,App.number)/App.number
                                         try:
                                             on_number = np.max(np.where(Prob>=array))+1
@@ -241,7 +241,7 @@ def Stochastic_Process(j):
                                     if np.in1d(peak_time_range,indexes).any() and App.fixed == 'no':
                                         coincidence = min(App.number,max(1,math.ceil(random.gauss((App.number*mu_peak+0.5),(s_peak*App.number*mu_peak)))))
                                     elif np.in1d(peak_time_range,indexes).any() == False and App.fixed == 'no':
-                                        Prob = random.uniform(0,(App.number-0.5)/App.number)
+                                        Prob = random.uniform(0,(App.number-op_factor)/App.number)
                                         array = np.arange(0,App.number)/App.number
                                         try:
                                             on_number = np.max(np.where(Prob>=array))+1


### PR DESCRIPTION
Potential improvements to on- and off-peak coincidence calculations. For off-peak, 0.5 chosen just as an example in the line: Prob = random.uniform(0,(App.number-0.5)/App.number). A different number between 0 and 1 could be chosen, with decreasing likelihood of maximum numerosity coincidence from 0 to 1.