### PR TITLE
Computation speed up via vectorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ This input file is used in [this publication](https://doi.org/10.1109/PTC.2019.8
 ### Spreadsheet input files
 It is also possible to use spreadsheets as input files. To do so you need to run the `ramp.py` file which is at the root of the repository with the option `-i`: `python ramp.py -i <path to .xlsx input file>`. If you already know how many profile you want to simulate you can indicate it with the `-n` option: `python ramp.py -i <path to .xlsx input file> -n 10` will simulate 10 profiles. Note that you can use this option without providing a `.xlsx` input file with the `-i` option, this will then be equivalent to running `python ramp_run.py` from the `ramp` folder without being prompted for the number of profile within the console.
 
+### Year simulation with different input parameters per month
+
+The following command (for windows user use `\` instead of `/`)
+`python ramp.py -i ramp/input_files/ -n 3 -y 2022`
+
+will simulate 3 daily profiles and average them to get a daily profile for each day of the whole year 2022, the averaged daily profiles are concatenated to a long timeseries for the year with minute resolution. It expects that 12 independant .xlsx input files are located in the folder `ramp/input_files/` and sorted numerically by month number (the sorted order is printed out at the execution of the function for the user to check)
+The results will be saved in the files `'yearly_profile_min_resolution.csv'` and `'yearly_profile_hour_resolution.csv'` for further data analysis for the time being (let us know in https://github.com/rl-institut/RAMP/issues/11 how you would like to be able to modify the file names and/or location)
+
 ### Convert python input files to xlsx
 If you have existing python input files, you can convert them to spreadsheet. To do so, go to `ramp` folder and run
 

--- a/ramp.py
+++ b/ramp.py
@@ -1,8 +1,13 @@
 import argparse
 import datetime
+import os.path
+import time
+
 import pandas as pd
+import numpy as np
 from ramp.ramp_run import run_usecase
 
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 parser = argparse.ArgumentParser(
     prog="python ramp_run.py", description="Execute RAMP code"
@@ -44,14 +49,23 @@ parser.add_argument(
     help="Date of end in YYYY-MM-DD format",
 )
 
-if __name__ == "__main__":
+parser.add_argument(
+    "--ext",
+    dest="extension",
+    type=str,
+    help="Format of input files",
+    default="xlsx"
+)
 
+if __name__ == "__main__":
+    ts = time.time()
     args = vars(parser.parse_args())
     fnames = args["fname_path"]
     num_profiles = args["num_profiles"]
     # Define which input files should be considered and run.
     date_start = args["date_start"]
     date_end = args["date_end"]
+    ext = args["extension"]
 
     years = args["years"]
 
@@ -62,17 +76,37 @@ if __name__ == "__main__":
         if date_end is None:
             date_end = datetime.date(date_start.year, 12, 31)
 
+    month_files = False
+
     if years is not None:
         if date_start is not None or date_end is not None:
             raise ValueError("You cannot use the option -y in combinaison with --date-start and/or --date-end")
         else:
             date_start = datetime.date(years[0], 1, 1)
             date_end = datetime.date(years[-1], 12, 31)
+        if len(years) == 1 and fnames is not None:
+            # This special combination (option -y with only 1 year and option -i with a directory as parameter)
+            # Triggers the special mode "one input file per month"
+            if os.path.isdir(fnames[0]):
+                fnames = [os.path.join(fnames[0], f) for f in os.listdir(fnames[0]) if f.endswith(ext)]
+                fnames.sort(key=lambda f: int(''.join(filter(str.isdigit, f))))
+
+                if len(fnames) == 12:
+                    print("The following input files were found and will be used in this exact order for month inputs")
+                    print("\n".join(fnames))
+                    month_files = True
+                    year = years[0]
+                else:
+                    raise ValueError(f"You want to simulate a whole year, yet the folder {fnames[0]} only contains {len(month_files)} out of the 12 monthes required ")
+            else:
+                print("You selected a single year but the input path is not a folder.")
+
 
     if date_start is not None and date_end is not None:
         days = pd.date_range(start=date_start, end=date_end)
     else:
         days = None
+
 
     if fnames is None:
         print("Please provide path to input file with option -i, \n\nDefault to old version of RAMP input files\n")
@@ -101,6 +135,27 @@ if __name__ == "__main__":
                         "The number of profiles parameters  should match the number of input files provided")
         else:
             num_profiles = [None] * len(fnames)
+        if month_files is True:
+            year_profile = []
+            for i, fname in enumerate(fnames):
+                month_start = datetime.date(year, i+1, 1)
+                month_end = datetime.date(year, i+1, pd.Period(month_start, freq="D").days_in_month)
+                days = pd.date_range(start=month_start, end=month_end, freq='D')
+                monthly_profiles = run_usecase(fname=fname, num_profiles=num_profiles[i], days=days, plot=False)
+                year_profile.append(np.hstack(monthly_profiles))
 
-        for i, fname in enumerate(fnames):
-            run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)
+            # Create a dataFrame to save the year profile with timestamps every minutes
+            series_frame = pd.DataFrame(
+                np.hstack(year_profile),
+                index=pd.date_range(start=f"{year}-1-1", end=f"{year}-12-31 23:59", freq="T")
+            )
+            # Save to minute and hour resolution
+            # TODO let the user choose where to save the files/file_name, make sure the user wants to overwrite the file
+            # if it already exists
+            series_frame.to_csv(os.path.join(BASE_PATH, 'yearly_profile_min_resolution.csv'))
+            series_frame.resample("H").sum().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
+        else:
+            for i, fname in enumerate(fnames):
+                run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)
+
+    print(f" Time elapsed: {time.time()-ts}")

--- a/ramp.py
+++ b/ramp.py
@@ -103,4 +103,4 @@ if __name__ == "__main__":
             num_profiles = [None] * len(fnames)
 
         for i, fname in enumerate(fnames):
-            run_usecase(fname=fname, num_profiles=num_profiles[i])
+            run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)

--- a/ramp.py
+++ b/ramp.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
             # TODO let the user choose where to save the files/file_name, make sure the user wants to overwrite the file
             # if it already exists
             series_frame.to_csv(os.path.join(BASE_PATH, 'yearly_profile_min_resolution.csv'))
-            series_frame.resample("H").sum().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
+            series_frame.resample("H").mean().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
         else:
             for i, fname in enumerate(fnames):
                 run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)

--- a/ramp.py
+++ b/ramp.py
@@ -88,7 +88,8 @@ if __name__ == "__main__":
             # This special combination (option -y with only 1 year and option -i with a directory as parameter)
             # Triggers the special mode "one input file per month"
             if os.path.isdir(fnames[0]):
-                fnames = [os.path.join(fnames[0], f) for f in os.listdir(fnames[0]) if f.endswith(ext)]
+                dir_path = fnames[0]
+                fnames = [os.path.join(dir_path, f) for f in os.listdir(fnames[0]) if f.endswith(ext)]
                 fnames.sort(key=lambda f: int(''.join(filter(str.isdigit, f))))
 
                 if len(fnames) == 12:
@@ -97,7 +98,7 @@ if __name__ == "__main__":
                     month_files = True
                     year = years[0]
                 else:
-                    raise ValueError(f"You want to simulate a whole year, yet the folder {fnames[0]} only contains {len(month_files)} out of the 12 monthes required ")
+                    raise ValueError(f"You want to simulate a whole year, yet the folder {dir_path} only contains {len(fnames)} out of the 12 monthes required")
             else:
                 print("You selected a single year but the input path is not a folder.")
 

--- a/ramp.py
+++ b/ramp.py
@@ -1,5 +1,6 @@
 import argparse
-
+import datetime
+import pandas as pd
 from ramp.ramp_run import run_usecase
 
 
@@ -21,6 +22,27 @@ parser.add_argument(
     help="number of profiles to be generated",
 )
 
+parser.add_argument(
+    "-y",
+    dest="years",
+    nargs="+",
+    type=int,
+    help="Years for which one should generate demand profiles",
+)
+
+parser.add_argument(
+    "--start-date",
+    dest="date_start",
+    type=datetime.date.fromisoformat,
+    help="Date of start in YYYY-MM-DD format",
+)
+
+parser.add_argument(
+    "--end-date",
+    dest="date_end",
+    type=datetime.date.fromisoformat,
+    help="Date of end in YYYY-MM-DD format",
+)
 
 if __name__ == "__main__":
 
@@ -28,6 +50,29 @@ if __name__ == "__main__":
     fnames = args["fname_path"]
     num_profiles = args["num_profiles"]
     # Define which input files should be considered and run.
+    date_start = args["date_start"]
+    date_end = args["date_end"]
+
+    years = args["years"]
+
+    if date_start is None:
+        if date_end is not None:
+            date_start = datetime.date(date_end.year, 1, 1)
+    else:
+        if date_end is None:
+            date_end = datetime.date(date_start.year, 12, 31)
+
+    if years is not None:
+        if date_start is not None or date_end is not None:
+            raise ValueError("You cannot use the option -y in combinaison with --date-start and/or --date-end")
+        else:
+            date_start = datetime.date(years[0], 1, 1)
+            date_end = datetime.date(years[-1], 12, 31)
+
+    if date_start is not None and date_end is not None:
+        days = pd.date_range(start=date_start, end=date_end)
+    else:
+        days = None
 
     if fnames is None:
         print("Please provide path to input file with option -i, \n\nDefault to old version of RAMP input files\n")

--- a/ramp.py
+++ b/ramp.py
@@ -154,7 +154,13 @@ if __name__ == "__main__":
             # TODO let the user choose where to save the files/file_name, make sure the user wants to overwrite the file
             # if it already exists
             series_frame.to_csv(os.path.join(BASE_PATH, 'yearly_profile_min_resolution.csv'))
-            series_frame.resample("H").mean().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
+            resampled = pd.DataFrame()
+
+            resampled["mean"] = series_frame.resample("H").mean()
+            resampled["max"] = series_frame.resample("H").max()
+            resampled["min"] = series_frame.resample("H").min()
+            #TODO add more columns with other resampled functions (do this in Jupyter)
+            resampled.to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
         else:
             for i, fname in enumerate(fnames):
                 run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)

--- a/ramp.py
+++ b/ramp.py
@@ -108,7 +108,6 @@ if __name__ == "__main__":
     else:
         days = None
 
-
     if fnames is None:
         print("Please provide path to input file with option -i, \n\nDefault to old version of RAMP input files\n")
         # Files are specified as numbers in a list (e.g. [1,2] will consider input_file_1.py and input_file_2.py)

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -244,7 +244,7 @@ class User:
             name=name,
         )
 
-    def generate_single_load_profile(self, prof_i, peak_time_range, Year_behaviour):
+    def generate_single_load_profile(self, prof_i, peak_time_range, day_type):
         """Generates a load profile for a single user taking all its appliances into consideration
 
         Parameters
@@ -253,8 +253,8 @@ class User:
             ith profile requested by the user
         peak_time_range: numpy array
             randomised peak time range calculated using calc_peak_time_range function
-        Year_behaviour: numpy array
-            array consisting of a yearly pattern of weekends and weekdays peak_time_range
+        day_type: int
+            0 for a week day or 1 for a weekend day
         """
 
         single_load = np.zeros(1440)
@@ -271,7 +271,7 @@ class User:
                      # evaluates if daily preference coincides with the randomised daily preference number
                      or (App.pref_index != 0 and rand_daily_pref != App.pref_index)
                      # checks if the app is allowed in the given yearly behaviour pattern
-                     or App.wd_we_type not in [Year_behaviour[prof_i], 2])
+                     or App.wd_we_type not in [day_type, 2])
             ):
                 continue
 
@@ -313,7 +313,7 @@ class User:
             single_load = single_load + App.daily_use  # adds the Appliance load profile to the single User load profile
         return single_load
 
-    def generate_aggregated_load_profile(self, prof_i, peak_time_range, Year_behaviour):
+    def generate_aggregated_load_profile(self, prof_i, peak_time_range, day_type):
         """Generates an aggregated load profile from single load profile of each user
 
             Each single load profile has its own separate randomisation
@@ -324,8 +324,8 @@ class User:
             ith profile requested by the user
         peak_time_range: numpy array
             randomised peak time range calculated using calc_peak_time_range function
-        Year_behaviour: numpy array
-            array consisting of a yearly pattern of weekends and weekdays peak_time_range
+        day_type: int
+            0 for a week day or 1 for a weekend day
 
         Returns
         -------
@@ -336,7 +336,7 @@ class User:
         self.load = np.zeros(1440)  # initialise empty load for User instance
         for _ in range(self.num_users):
             # iterates for every single user within a User class.
-            self.load = self.load + self.generate_single_load_profile(prof_i, peak_time_range, Year_behaviour)
+            self.load = self.load + self.generate_single_load_profile(prof_i, peak_time_range, day_type)
 
 
 class Appliance:

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -8,7 +8,8 @@ import warnings
 import random
 import math
 from ramp.core.constants import NEW_TO_OLD_MAPPING, APPLIANCE_ATTRIBUTES, APPLIANCE_ARGS, WINDOWS_PARAMETERS, DUTY_CYCLE_PARAMETERS, switch_on_parameters
-from ramp.core.utils import random_variation, duty_cycle, random_choice, read_input_file
+from ramp.core.utils import random_variation, duty_cycle, random_choice, read_input_file, calc_time_taken
+
 
 #%% Definition of Python classes that constitute the model architecture
 """
@@ -244,6 +245,7 @@ class User:
             name=name,
         )
 
+    @calc_time_taken
     def generate_single_load_profile(self, prof_i, peak_time_range, day_type):
         """Generates a load profile for a single user taking all its appliances into consideration
 
@@ -313,6 +315,7 @@ class User:
             single_load = single_load + App.daily_use  # adds the Appliance load profile to the single User load profile
         return single_load
 
+    @calc_time_taken
     def generate_aggregated_load_profile(self, prof_i, peak_time_range, day_type):
         """Generates an aggregated load profile from single load profile of each user
 

--- a/ramp/core/initialise.py
+++ b/ramp/core/initialise.py
@@ -7,15 +7,6 @@ import importlib
 from ramp.core.core import UseCase
 
 
-def yearly_pattern():
-    """Definition of a yearly pattern of weekends and weekdays, in case some appliances have specific wd/we behaviour"""
-
-    year_behaviour = np.zeros(365)
-    year_behaviour[5:365:7] = 1
-    year_behaviour[6:365:7] = 1
-
-    return year_behaviour
-
 
 def user_defined_inputs(j=None, fname=None):
     """Imports an input file and returns a processed user_list
@@ -64,7 +55,6 @@ def initialise_inputs(j=None, fname=None, num_profiles=None):
 
     """
 
-    year_behaviour = yearly_pattern()
     user_list = user_defined_inputs(j, fname)
 
     peak_enlarge = 0.15  # percentage random enlargement or reduction of peak time range length, corresponds to \delta_{peak} in [1], p.7
@@ -76,4 +66,4 @@ def initialise_inputs(j=None, fname=None, num_profiles=None):
         )
         print("Please wait...")
 
-    return (peak_enlarge, year_behaviour, user_list, num_profiles)
+    return (peak_enlarge, user_list, num_profiles)

--- a/ramp/core/initialise.py
+++ b/ramp/core/initialise.py
@@ -5,6 +5,7 @@
 import numpy as np
 import importlib
 from ramp.core.core import UseCase
+from ramp.core.utils import calc_time_taken
 
 
 
@@ -36,7 +37,7 @@ def user_defined_inputs(j=None, fname=None):
 
     return user_list
 
-
+@calc_time_taken
 def initialise_inputs(j=None, fname=None, num_profiles=None):
     """Loads the provided input file and prompt the user for number of profiles if not defined
 

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -69,7 +69,7 @@ def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
     # creates an empty list to store the results of each code run, i.e. each stochastically generated profile
     profiles = []
 
-    peak_enlarge, year_behaviour, user_list, num_profiles = initialise_inputs(j, fname, num_profiles)
+    peak_enlarge, user_list, num_profiles = initialise_inputs(j, fname, num_profiles)
 
     # Calculation of the peak time range, which is used to discriminate between off-peak
     # and on-peak coincident switch-on probability, corresponds to step 1. of [1], p.6

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -52,10 +52,13 @@ def calc_peak_time_range(user_list, peak_enlarge=0.15):
     return np.arange(peak_time - rand_peak_enlarge, peak_time + rand_peak_enlarge)
 
 
-def stochastic_process(j=None, fname=None, num_profiles=None):
+def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
     """Generate num_profiles load profile for the usecase
 
         Covers steps 1. and 2. of the algorithm described in [1], p.6-7
+
+    day_type: int
+        0 for a week day or 1 for a weekend day
 
     Notes
     -----
@@ -79,11 +82,11 @@ def stochastic_process(j=None, fname=None, num_profiles=None):
         # for each User instance generate a load profile, iterating through all user of this instance and
         # all appliances they own, corresponds to step 2. of [1], p.7
         for user in user_list:
-            user.generate_aggregated_load_profile(prof_i, peak_time_range, year_behaviour)
+            user.generate_aggregated_load_profile(prof_i, peak_time_range, day_type)
             # aggregate the user load to the usecase load
             usecase_load = usecase_load + user.load
         profiles.append(usecase_load)
         # screen update about progress of computation
         print('Profile', prof_i+1, '/', num_profiles, 'completed')
-    return(profiles)
+    return profiles
 

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -52,7 +52,7 @@ def calc_peak_time_range(user_list, peak_enlarge=0.15):
     return np.arange(peak_time - rand_peak_enlarge, peak_time + rand_peak_enlarge)
 
 
-def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
+def stochastic_process(j=None, fname=None, num_profiles=None, day_type=None):
     """Generate num_profiles load profile for the usecase
 
         Covers steps 1. and 2. of the algorithm described in [1], p.6-7
@@ -75,14 +75,24 @@ def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
     # and on-peak coincident switch-on probability, corresponds to step 1. of [1], p.6
     peak_time_range = calc_peak_time_range(user_list, peak_enlarge)
 
+    if isinstance(day_type, list):
+        yearly_day_types = day_type
+    else:
+        yearly_day_types = None
+
     for prof_i in range(num_profiles):
         # initialise an empty daily profile (or profile load)
         # that will be filled with the sum of the daily profiles of each User instance
         usecase_load = np.zeros(1440)
+
+        # assign day_type between weekend and weekdays
+        if yearly_day_types is not None:
+            day_type = yearly_day_types[prof_i]
+
         # for each User instance generate a load profile, iterating through all user of this instance and
         # all appliances they own, corresponds to step 2. of [1], p.7
         for user in user_list:
-            user.generate_aggregated_load_profile(prof_i, peak_time_range, day_type)
+            user.generate_aggregated_load_profile(prof_i, peak_time_range, day_type=day_type)
             # aggregate the user load to the usecase load
             usecase_load = usecase_load + user.load
         profiles.append(usecase_load)

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -5,10 +5,11 @@ import numpy as np
 import random 
 import math
 from ramp.core.initialise import initialise_inputs
+from ramp.core.utils import calc_time_taken
 
 #%% Core model stochastic script
 
-
+@calc_time_taken
 def calc_peak_time_range(user_list, peak_enlarge=0.15):
     """
     Calculate the peak time range, which is used to discriminate between off-peak and on-peak coincident switch-on probability
@@ -51,7 +52,7 @@ def calc_peak_time_range(user_list, peak_enlarge=0.15):
     # The peak_time is randomly enlarged based on the calibration parameter peak_enlarge
     return np.arange(peak_time - rand_peak_enlarge, peak_time + rand_peak_enlarge)
 
-
+@calc_time_taken
 def stochastic_process(j=None, fname=None, num_profiles=None, day_type=None):
     """Generate num_profiles load profile for the usecase
 

--- a/ramp/core/utils.py
+++ b/ramp/core/utils.py
@@ -163,3 +163,12 @@ def random_choice(var, t1, p1, t2, p2):
             duty_cycle(var, t1=t2, p1=p2, t2=t1, p2=p1),
         ]
     )
+
+
+def get_day_type(day):
+    """Given a datetime object return 0 for weekdays or 1 for weekends"""
+    if day.weekday() > 4:
+        answer = 1
+    else:
+        answer = 0
+    return answer

--- a/ramp/core/utils.py
+++ b/ramp/core/utils.py
@@ -1,5 +1,6 @@
 import json
 import random
+import datetime
 import numpy as np
 import pandas as pd
 from openpyxl import load_workbook
@@ -172,3 +173,20 @@ def get_day_type(day):
     else:
         answer = 0
     return answer
+
+
+def yearly_pattern(year=None):
+    """
+    Definition of a yearly pattern of weekends and weekdays, in case some appliances have specific wd/we behaviour
+    If no argument is provided, the pattern always starts a monday and lasts 365 days, otherwise the pattern matches
+    the weekdays and weekends of the provided year
+    """
+    if year is None:
+        year_behaviour = np.zeros(365)
+        year_behaviour[5:365:7] = 1
+        year_behaviour[6:365:7] = 1
+        year_behaviour = year_behaviour.tolist()
+    else:
+        # a list with 0 for weekdays and 1 for weekends
+        year_behaviour = pd.date_range(start=f"{year}-01-01", end=f"{year}-12-31", freq="D").map(get_day_type).to_list()
+    return year_behaviour

--- a/ramp/core/utils.py
+++ b/ramp/core/utils.py
@@ -1,6 +1,6 @@
 import json
 import random
-import datetime
+import time
 import numpy as np
 import pandas as pd
 from openpyxl import load_workbook
@@ -165,7 +165,6 @@ def random_choice(var, t1, p1, t2, p2):
         ]
     )
 
-
 def get_day_type(day):
     """Given a datetime object return 0 for weekdays or 1 for weekends"""
     if day.weekday() > 4:
@@ -190,3 +189,13 @@ def yearly_pattern(year=None):
         # a list with 0 for weekdays and 1 for weekends
         year_behaviour = pd.date_range(start=f"{year}-01-01", end=f"{year}-12-31", freq="D").map(get_day_type).to_list()
     return year_behaviour
+
+def calc_time_taken(func):
+    """ Calculates the time elapsed during the execution of a function"""
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        result = func(*args, **kwargs)
+        end = time.time()
+        print(func.__name__ + ' required ' + str((end-start)*1) + ' seconds for execution. ')
+        return result
+    return wrapper

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -20,16 +20,15 @@ parser.add_argument(
 parser.add_argument(
     "-o",
     dest="output_path",
-    nargs=1,
     type=str,
     help="path where to save the converted filename",
 )
 parser.add_argument(
     "--suffix",
     dest="suffix",
-    nargs=1,
     type=str,
     help="suffix appended to the converted filename",
+    default=""
 )
 
 
@@ -49,11 +48,24 @@ def convert_old_user_input_file(
     Imports an input file from a path and returns a processed User_list
     """
 
+    line_to_change = -1
+
     # Check if the lines to save the names of the Appliance instances is already there
+    # And check if the import of the User class is correct, otherwise adapt the file
     with open(fname_path, "r") as fp:
         lines = fp.readlines()
         if "# Code automatically added by ramp_convert_old_input_files.py\n" in lines:
             keep_names = False
+        for i, l in enumerate(lines):
+            if "from core import" in l:
+                line_to_change = i
+        # Change import statement by explicitly naming the full package path
+        lines[line_to_change] = lines[line_to_change].replace("from core import", "from ramp.core.core import")
+
+    # Modify import statement in file
+    if line_to_change != -1:
+        with open(fname_path, "w") as fp:
+            fp.writelines(lines)
 
     # Add code to the input file to assign the variable name of the Appliance instances to their name attribute
     if keep_names is True:
@@ -82,14 +94,6 @@ if __name__ == "__main__":
     fname = args["fname_path"]
     output_path = args.get("output_path")
     suffix = args.get("suffix")
-
-    if output_path is not None:
-        output_path = output_path[0]
-
-    if suffix is None:
-        suffix = ""
-    else:
-        suffix = suffix[0]
 
     if fname is None:
         print("Please provide path to input file with option -i")

--- a/ramp/ramp_run.py
+++ b/ramp/ramp_run.py
@@ -24,28 +24,50 @@ under the License.
 #%% Import required modules
 
 import sys,os
+
+import numpy as np
+
 sys.path.append('../')
 
 try:
+    from .core.utils import get_day_type
     from .core.stochastic_process import stochastic_process
     from .post_process import post_process as pp
 except ImportError:
+    from core.utils import get_day_type
     from core.stochastic_process import stochastic_process
     from post_process import post_process as pp
 
 
-def run_usecase(j=None, fname=None, num_profiles=None):
+def run_usecase(j=None, fname=None, num_profiles=None, days=None):
     # Calls the stochastic process and saves the result in a list of stochastic profiles
-    Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles)
+    if days is None:
+        Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=0)
 
-    # Post-processes the results and generates plots
-    Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
-    pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
+        # Post-processes the results and generates plots
+        Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
+        pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
 
-    pp.export_series(Profiles_series, j, fname)
+        pp.export_series(Profiles_series, j, fname)
 
-    if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
-        pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+        if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
+            pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+    else:
+        Profiles_list = []
+        for day in days:
+            print("Day", day)
+            daily_profiles = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=get_day_type(day))
+
+            Profiles_list.append(np.mean(daily_profiles, axis=0))
+
+        # Post-processes the results and generates plots
+        Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
+        pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
+
+        pp.export_series(Profiles_series, j, fname)
+
+        if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
+            pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
 
 
 input_files_to_run = [1, 2, 3]

--- a/ramp/ramp_run.py
+++ b/ramp/ramp_run.py
@@ -39,7 +39,7 @@ except ImportError:
     from post_process import post_process as pp
 
 
-def run_usecase(j=None, fname=None, num_profiles=None, days=None):
+def run_usecase(j=None, fname=None, num_profiles=None, days=None, plot=True):
     # Calls the stochastic process and saves the result in a list of stochastic profiles
     if days is None:
         Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=0)
@@ -59,15 +59,17 @@ def run_usecase(j=None, fname=None, num_profiles=None, days=None):
             daily_profiles = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=get_day_type(day))
 
             Profiles_list.append(np.mean(daily_profiles, axis=0))
+        if plot is True:
+            # Post-processes the results and generates plots
+            Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
+            pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
 
-        # Post-processes the results and generates plots
-        Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
-        pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
+            pp.export_series(Profiles_series, j, fname)
 
-        pp.export_series(Profiles_series, j, fname)
-
-        if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
-            pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+            if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
+                pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+        else:
+            return Profiles_list
 
 
 input_files_to_run = [1, 2, 3]

--- a/ramp/ramp_run.py
+++ b/ramp/ramp_run.py
@@ -30,11 +30,11 @@ import numpy as np
 sys.path.append('../')
 
 try:
-    from .core.utils import get_day_type
+    from .core.utils import get_day_type, yearly_pattern
     from .core.stochastic_process import stochastic_process
     from .post_process import post_process as pp
 except ImportError:
-    from core.utils import get_day_type
+    from core.utils import get_day_type, yearly_pattern
     from core.stochastic_process import stochastic_process
     from post_process import post_process as pp
 
@@ -42,7 +42,7 @@ except ImportError:
 def run_usecase(j=None, fname=None, num_profiles=None, days=None, plot=True):
     # Calls the stochastic process and saves the result in a list of stochastic profiles
     if days is None:
-        Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=0)
+        Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=yearly_pattern())
 
         # Post-processes the results and generates plots
         Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)

--- a/tests/test_input_file_conversion.py
+++ b/tests/test_input_file_conversion.py
@@ -9,7 +9,7 @@ from ramp.ramp_convert_old_input_files import convert_old_user_input_file
 
 
 def load_usecase(j=None, fname=None):
-    peak_enlarge, year_behaviour, user_list, num_profiles = initialise_inputs(
+    peak_enlarge, user_list, num_profiles = initialise_inputs(
         j, fname, num_profiles=1
     )
     return user_list


### PR DESCRIPTION
This is based on #52, which has to be merged prior to merging this

Running a usecase with 1 profile, one user_type and 100 users on my laptop led to the following times:
- `generate_single_load_profile` took approximately 0.0027 seconds to run 
- `generate_aggregated_load_profile` needed about 100 times that (`num_user` was set to 100, so nothing wrong here)
- `stochastic_process` took 2.4 seconds to complete but 2.1 s where used by the `initialise.initialise_inputs` bit

This is roughly a minute and a half for a whole year.

The time taken is the same as if I use numpy.random.rand to generate a profile with 1440 for each single user in this dummy code

``` 
import numpy as np
from ramp.core.utils import calc_time_taken
num_profile  = 365
user_list = [1]
num_users = 100

def generate_single_profile():
    return np.random.rand(1440,1)


def generate_aggrated_profile(nu):
    load = np.zeros(1440)
    for u in range(nu):
        load = load + generate_single_profile()
    return load
profiles = []

@calc_time_taken
def stochastic_process(num_profile):
    for prof_i in range(num_profile):
        usecase_load = np.zeros(1440)
        for user in user_list:
            user_load = generate_aggrated_profile(num_users)
                # aggregate the user load to the usecase load
            usecase_load = usecase_load + user_load
        profiles.append(usecase_load)

stochastic_process(num_profile)
```

This can be used to easily compare various speedup strategy and only implement the most successful one