### PR TITLE
Function download_example does not work (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.4.1 (dev)
+------------------
+
+**|fixed|**     automated download of example applications via the `download_example` functions now includes previously missing .csv files
+
+
 0.4.0 (2023-02-17)
 ------------------
 

--- a/ramp/example/examples.py
+++ b/ramp/example/examples.py
@@ -29,7 +29,7 @@ def download_example(destination:str):
     destination : str
         The path to copy the model files.
     """
-    files = ["input_file_1.py","input_file_2.py","input_file_3.py","shower_P.csv"]
+    files = ["input_file_1.py","input_file_2.py","input_file_3.py","shower_P.csv","daily_T.csv","T_gw.csv"]
 
     for file in files:
         shutil.copyfile(src=f"{path}/{file}", dst=f"{destination}/{file}")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages= find_packages(),
     license="European Union Public License 1.2",
     python_requires = ">=3.6.0",
-    package_data={"": ["*.txt", "*.dat", "*.doc", "*.rst","*.xlsx"]},
+    package_data={"": ["*.txt", "*.dat", "*.doc", "*.rst","*.xlsx","*.csv"]},
     install_requires = [
         "pandas >= 1.3.3",
         "numpy >= 1.21.2",


### PR DESCRIPTION
Issue opened originally by @LorenzoRinaldi.

Description of the issue:
"download_example" function (ramp\example\examples.py) and it seems there is an issue with the "shower_p.csv" file, which i guess it is supposed to be present in the folder "site-packages\ramp\example" but it is not. the issue is related to the fact that ".csv" files are not included in the package_data argument in setup.py.

Changes:
----------

1. setup.py: adding "*.csv" to the packge_data

2. ramp/core/example/examples.py --> function "download_example": adding all the csv files of the example to the list of downloadable files

Test:
------
The new change is tested locally by creating the source dist files and installing using pip install -e .