### PR TITLE
Skip appliance if func_time==0 or rand_time==0

### DIFF
--- a/ramp/__init__.py
+++ b/ramp/__init__.py
@@ -13,7 +13,6 @@ Package dependencies:
     - random
 """
 
-
 from ramp._version import __version__
 from ramp.core.core import UseCase, User, Appliance
 from ramp.core.utils import yearly_pattern, get_day_type

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -1029,7 +1029,6 @@ class Appliance:
             2. power array size is not (366,1)
         """
 
-
         self.user = user
         self.name = name
         self.number = number
@@ -1037,7 +1036,9 @@ class Appliance:
 
         if func_time == 0:
             warnings.warn(
-                UserWarning(f"Func_time of appliance '{self.name}' is defined as 0. Ignore if this is intended")
+                UserWarning(
+                    f"Func_time of appliance '{self.name}' is defined as 0. Ignore if this is intended"
+                )
             )
 
         self.func_time = func_time
@@ -1854,7 +1855,9 @@ class Appliance:
         ]
 
         tot_time = 0
-        while tot_time <= rand_time and rand_time != 0:  # Check if rand_time is 0 (-> fix issue 114)
+        while (
+            tot_time <= rand_time and rand_time != 0
+        ):  # Check if rand_time is 0 (-> fix issue 114)
             # one option could be to generate a lot of them at once
             indexes = self.rand_switch_on_window(
                 rand_time=rand_time,  # TODO maybe only consider rand_time-tot_time ...

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -1029,10 +1029,17 @@ class Appliance:
             2. power array size is not (366,1)
         """
 
+
         self.user = user
         self.name = name
         self.number = number
         self.num_windows = num_windows
+
+        if func_cycle == 0:
+            warnings.warn(
+                UserWarning(f"Func_time of appliance '{self.name}' is defined as 0. Ignore if this is intended")
+            )
+
         self.func_time = func_time
         self.time_fraction_random_variability = time_fraction_random_variability
         self.func_cycle = func_cycle
@@ -1847,7 +1854,7 @@ class Appliance:
         ]
 
         tot_time = 0
-        while tot_time <= rand_time and rand_time!=0:  # Check if rand_time is 0 (-> fix issue 114)
+        while tot_time <= rand_time and rand_time != 0:  # Check if rand_time is 0 (-> fix issue 114)
             # one option could be to generate a lot of them at once
             indexes = self.rand_switch_on_window(
                 rand_time=rand_time,  # TODO maybe only consider rand_time-tot_time ...

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -1799,6 +1799,8 @@ class Appliance:
             or (self.pref_index != 0 and self.user.rand_daily_pref != self.pref_index)
             # checks if the app is allowed in the given yearly behaviour pattern
             or self.wd_we_type not in [day_type, 2]
+            # check if the app has a func_time of 0 (fix issue 114)
+            or self.func_time == 0
         ):
             return
 
@@ -1845,7 +1847,7 @@ class Appliance:
         ]
 
         tot_time = 0
-        while tot_time <= rand_time:
+        while tot_time <= rand_time and rand_time!=0:  # Check if rand_time is 0 (-> fix issue 114)
             # one option could be to generate a lot of them at once
             indexes = self.rand_switch_on_window(
                 rand_time=rand_time,  # TODO maybe only consider rand_time-tot_time ...

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -1035,7 +1035,7 @@ class Appliance:
         self.number = number
         self.num_windows = num_windows
 
-        if func_cycle == 0:
+        if func_time == 0:
             warnings.warn(
                 UserWarning(f"Func_time of appliance '{self.name}' is defined as 0. Ignore if this is intended")
             )

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -1807,7 +1807,7 @@ class Appliance:
             or (self.pref_index != 0 and self.user.rand_daily_pref != self.pref_index)
             # checks if the app is allowed in the given yearly behaviour pattern
             or self.wd_we_type not in [day_type, 2]
-            # check if the app has a func_time of 0 (fix issue 114)
+            # skip if the app has a func_time of 0
             or self.func_time == 0
         ):
             return
@@ -1855,9 +1855,7 @@ class Appliance:
         ]
 
         tot_time = 0
-        while (
-            tot_time <= rand_time and rand_time != 0
-        ):  # Check if rand_time is 0 (-> fix issue 114)
+        while tot_time <= rand_time and rand_time != 0:
             # one option could be to generate a lot of them at once
             indexes = self.rand_switch_on_window(
                 rand_time=rand_time,  # TODO maybe only consider rand_time-tot_time ...

--- a/tests/test_func_time_zero.py
+++ b/tests/test_func_time_zero.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from ramp import UseCase, User
 
+
 def test_skip_when_func_time_zero():
 
     # Generate test user and appliance
@@ -14,22 +15,22 @@ def test_skip_when_func_time_zero():
     )
 
     # Add to use_case
-    use_case = UseCase(
-        name='test_use_case',
-        users=[user]
-    )
+    use_case = UseCase(name="test_use_case", users=[user])
 
     # Calculate peak time range for this use_case
     peak_time_range = use_case.calc_peak_time_range()
 
     # Generated one load profile of this appliance
     power = 1000
-    appliance.generate_load_profile(prof_i=0, peak_time_range=peak_time_range, day_type=0, power=power)
+    appliance.generate_load_profile(
+        prof_i=0, peak_time_range=peak_time_range, day_type=0, power=power
+    )
 
     # Check that no use of this appliance is simulated -> the appliances load profile is always smaller than it's power
     # (Checking for the load_profile to always be 0 might be unreliable, since the RAMP core "marks" potential usage
     # windows with small power values larger 0)
     assert np.max(appliance.daily_use) < power
+
 
 def test_warning_when_func_time_zero():
     user = User(user_name="Test User", num_users=1)
@@ -39,6 +40,7 @@ def test_warning_when_func_time_zero():
         func_cycle=20,
         time_fraction_random_variability=0.1,
     )
+
 
 with pytest.warns():
     test_warning_when_func_time_zero()

--- a/tests/test_func_time_zero.py
+++ b/tests/test_func_time_zero.py
@@ -4,7 +4,6 @@ from ramp import UseCase, User
 
 
 def test_skip_when_func_time_zero():
-
     # Generate test user and appliance
     user = User(user_name="Test User", num_users=1)
     appliance = user.add_appliance(
@@ -34,13 +33,10 @@ def test_skip_when_func_time_zero():
 
 def test_warning_when_func_time_zero():
     user = User(user_name="Test User", num_users=1)
-    appliance = user.add_appliance(
-        name="Test Appliance",
-        func_time=0,  # Set func_time to be 0
-        func_cycle=20,
-        time_fraction_random_variability=0.1,
-    )
-
-
-with pytest.warns():
-    test_warning_when_func_time_zero()
+    with pytest.warns():
+        appliance = user.add_appliance(
+            name="Test Appliance",
+            func_time=0,  # Set func_time to be 0
+            func_cycle=20,
+            time_fraction_random_variability=0.1,
+        )

--- a/tests/test_func_time_zero.py
+++ b/tests/test_func_time_zero.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+from ramp import UseCase, User
+
+def test_skip_when_func_time_zero():
+
+    # Generate test user and appliance
+    user = User(user_name="Test User", num_users=1)
+    appliance = user.add_appliance(
+        name="Test Appliance",
+        func_time=0,  # Set func_time to be 0
+        func_cycle=20,
+        time_fraction_random_variability=0.1,
+    )
+
+    # Add to use_case
+    use_case = UseCase(
+        name='test_use_case',
+        users=[user]
+    )
+
+    # Calculate peak time range for this use_case
+    peak_time_range = use_case.calc_peak_time_range()
+
+    # Generated one load profile of this appliance
+    power = 1000
+    appliance.generate_load_profile(prof_i=0, peak_time_range=peak_time_range, day_type=0, power=power)
+
+    # Check that no use of this appliance is simulated -> the appliances load profile is always smaller than it's power
+    # (Checking for the load_profile to always be 0 might be unreliable, since the RAMP core "marks" potential usage
+    # windows with small power values larger 0)
+    assert np.max(appliance.daily_use) < power
+
+def test_warning_when_func_time_zero():
+    user = User(user_name="Test User", num_users=1)
+    appliance = user.add_appliance(
+        name="Test Appliance",
+        func_time=0,  # Set func_time to be 0
+        func_cycle=20,
+        time_fraction_random_variability=0.1,
+    )
+
+with pytest.warns():
+    test_warning_when_func_time_zero()


### PR DESCRIPTION
Fix #114 

Implemented fix as proposed in [issue 114](https://github.com/RAMP-project/RAMP/issues/114):
- add `rand_time!=0` as condition in the while loop of function `Appliance.generate_load_profile`. This way, appliances are skipped when the `rand_time` is calculated to be 0, which can happen when `time_fraction_random_variability` is set to 1.

One small addition:
- first check if self.func_time==0 (line 1803) -> if so, appliance is skipped directly, without calculating rand_time. Otherwise, `Appliance.rand_total_time_of_use` can throw error.
