### PR TITLE
User empty object print ValueError

### DIFF
--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -657,21 +657,19 @@ class User:
         )  # each instance of User (i.e. each user class) has its own list of Appliances
 
     def __str__(self):
-
         try:
             return self.save()[
                 ["user_name", "num_users", "name", "number", "power"]
             ].to_string()
-        
+
         except Exception:
-            return (f"""
+            return f"""
 user_name: {self.user_name} \n
 num_users: {self.num_users} \n
 appliances: no appliances assigned to the user.
-                    """)
-        
-    def __repr__(self):
+                    """
 
+    def __repr__(self):
         return self.__str__()
 
     def _add_appliance_instance(self, appliances):

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -656,10 +656,23 @@ class User:
             []
         )  # each instance of User (i.e. each user class) has its own list of Appliances
 
+    def __str__(self):
+
+        try:
+            return self.save()[
+                ["user_name", "num_users", "name", "number", "power"]
+            ].to_string()
+        
+        except Exception:
+            return (f"""
+user_name: {self.user_name} \n
+num_users: {self.num_users} \n
+appliances: no appliances assigned to the user.
+                    """)
+        
     def __repr__(self):
-        return self.save()[
-            ["user_name", "num_users", "name", "number", "power"]
-        ].to_string()
+
+        return self.__str__()
 
     def add_appliance(self, *args, **kwargs):
         """adds an appliance to the user category with all the appliance characteristics in a single function

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -1230,7 +1230,7 @@ class Appliance:
         answer = np.array([])
         for attribute in APPLIANCE_ATTRIBUTES:
             if hasattr(self, attribute) and hasattr(other_appliance, attribute):
-                np.append(
+                answer = np.append(
                     answer,
                     [getattr(self, attribute) == getattr(other_appliance, attribute)],
                 )
@@ -1238,7 +1238,7 @@ class Appliance:
                 hasattr(self, attribute) is False
                 and hasattr(other_appliance, attribute) is False
             ):
-                np.append(answer, True)
+                answer = np.append(answer, [True])
             else:
                 if hasattr(self, attribute) is False:
                     print(f"{attribute} of appliance {self.name} is not assigned")
@@ -1246,7 +1246,7 @@ class Appliance:
                     print(
                         f"{attribute} of appliance {other_appliance.name} is not assigned"
                     )
-                np.append(answer, False)
+                answer = np.append(answer, [False])
         return answer.all()
 
     def windows(

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -674,6 +674,17 @@ appliances: no appliances assigned to the user.
 
         return self.__str__()
 
+    def _add_appliance_instance(self, appliances):
+        if isinstance(appliances, Appliance):
+            appliances = [appliances]
+        for app in appliances:
+            if not isinstance(app, Appliance):
+                raise TypeError(
+                    f"You are trying to add an object of type {type(app)} as an appliance to the user {self.user_name}"
+                )
+            if app not in self.App_list:
+                self.App_list.append(app)
+
     def add_appliance(self, *args, **kwargs):
         """adds an appliance to the user category with all the appliance characteristics in a single function
 
@@ -686,7 +697,13 @@ appliances: no appliances assigned to the user.
 
         # parse the args into the kwargs
         if len(args) > 0:
+            if isinstance(args[0], Appliance):
+                # if the first argument is an Appliance instance, it is assumed all arguments are
+                # if this is not the case, error will be thrown by _add_appliance_instance method
+                self._add_appliance_instance(args)
+                return
             for a_name, a_val in zip(APPLIANCE_ARGS, args):
+                # TODO here we could do validation of the arguments
                 kwargs[a_name] = a_val
 
         # collects windows arguments
@@ -711,6 +728,8 @@ appliances: no appliances assigned to the user.
             app.windows(**windows_args)
         for i in duty_cycle_parameters:
             app.specific_cycle(i, **duty_cycle_parameters[i])
+
+        self._add_appliance_instance(app)
 
         return app
 
@@ -1329,9 +1348,9 @@ class Appliance:
         )  # calculate the random variability of window1, i.e. the maximum range of time they can be enlarged or shortened
         self.random_var_2 = int(random_var_w * np.diff(self.window_2))  # same as above
         self.random_var_3 = int(random_var_w * np.diff(self.window_3))  # same as above
-        self.user.App_list.append(
-            self
-        )  # automatically appends the appliance to the user's appliance list
+
+        # automatically appends the appliance to the user's appliance list
+        self.user._add_appliance_instance(self)
 
         if self.fixed_cycle == 1:
             self.cw11 = self.window_1

--- a/tests/test_object_comparison.py
+++ b/tests/test_object_comparison.py
@@ -1,0 +1,33 @@
+import pytest
+from ramp import User, Appliance
+
+
+@pytest.fixture
+def test_user():
+    # Create a User instance (you may need to provide the required arguments for User)
+    user = User(user_name="Test User", num_users=1)
+    return user
+
+
+@pytest.mark.usefixtures("test_user")
+def test_compare_two_appliances():
+    appliance1 = Appliance(
+        test_user,
+        name="test_appliance1",
+        func_time=4 * 60,  # runs for 4 hours per day
+    )
+
+    appliance2 = Appliance(
+        test_user,
+        name="test_appliance2",
+        func_time=4 * 60,  # runs for 4 hours per day
+    )
+
+    appliance3 = Appliance(
+        test_user,
+        name="test_appliance1",
+        func_time=4 * 60,  # runs for 4 hours per day
+    )
+
+    assert appliance1 != appliance2
+    assert appliance1 == appliance3

--- a/tests/test_object_comparison.py
+++ b/tests/test_object_comparison.py
@@ -10,7 +10,7 @@ def test_user():
 
 
 @pytest.mark.usefixtures("test_user")
-def test_compare_two_appliances():
+def test_compare_two_appliances(test_user):
     appliance1 = Appliance(
         test_user,
         name="test_appliance1",

--- a/tests/test_object_creation.py
+++ b/tests/test_object_creation.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ramp import User, Appliance
+
+
+@pytest.fixture
+def test_user():
+    # Create a User instance (you may need to provide the required arguments for User)
+    user = User(user_name="Test User", num_users=1)
+    return user
+
+
+@pytest.mark.usefixtures("test_user")
+def test_add_several_appliances_to_user(test_user):
+    assert len(test_user.App_list) == 0
+    appliance1 = Appliance(
+        test_user,
+        name="test_appliance1",
+        func_time=4 * 60,  # runs for 4 hours per day
+    )
+    appliance2 = Appliance(
+        test_user,
+        name="test_appliance2",
+        func_time=4 * 60,  # runs for 4 hours per day
+    )
+    test_user.add_appliance(appliance1, appliance2)
+    assert len(test_user.App_list) == 2
+
+
+@pytest.mark.usefixtures("test_user")
+def test_skip_add_existing_appliances_to_user(test_user):
+    assert len(test_user.App_list) == 0
+    appliance1 = Appliance(
+        test_user,
+        name="test_appliance1",
+        func_time=4 * 60,  # runs for 4 hours per day
+    )
+    test_user.add_appliance(appliance1)
+
+    assert len(test_user.App_list) == 1
+
+    test_user.add_appliance(appliance1)
+
+    assert len(test_user.App_list) == 1


### PR DESCRIPTION
issue:
When a user object is empty cannot be printed due as the __repr__ method uses the save() method to print the properties of the users, which raise Exception in case no appliances are added to the user.

solution:
in case save() methods returns an exception, the function prints the user_name, and user_num with a message to mention no appliances are assigned to the user object yet.

additional:
- found a bug in `__eq__` method of `Appliance` class and fixed it
- add the possibility for a user to pass directly `Appliance` instances to the `add_appliance` method of the `User` class
- add two new test files