### PR TITLE
Python=3.8 to be outdated as the prefered python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Installing through pip
 
 .. code-block:: python
 
-   conda create -n ramp python=3.8
+   conda create -n ramp python=3.10
 
 
 2. If you create a new environment for RAMP, you'll need to activate it each time before using it, by writing

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: ramp
 dependencies:
-- python=3.8
+- python=3.10
 - pip=21.0.1
 - pip:
    - -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     license="European Union Public License 1.2",
-    python_requires=">=3.6.0",
+    python_requires="<=3.10",
     package_data={"": ["*.txt", "*.dat", "*.doc", "*.rst", "*.xlsx", "*.csv"]},
     install_requires=[
         "pandas >= 1.3.3",


### PR DESCRIPTION
issue:

Python 3.8 is mentioned in the README as the preferred python version for the installation. However, this python version is going to be outdated by October 2024.

Current RAMP dev can be safely used by python 3.10.

Changes:

- README.rst --> updating the installation guide
- environment.yml --> updating the python dependency for installing environment through yml file
 - setup.py --> updating the python_requires accordingly