### PR TITLE
Add ramp_convert .py to .xlsx files to command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,13 +193,15 @@ Other options are documented in the help of `ramp`, which you access with the ``
    ramp -h
 
 
-If you have existing python input files, you can convert them to
-spreadsheet. Simply run
+If you have existing python input files from RAMP version prior to 0.5, you can convert them to
+spreadsheets input files. Simply run
 
 .. code-block:: bash
 
-   ramp_convert -i <path to the input file you wish to convert>
+   ramp_convert -i <path to the .py input file you wish to convert>
 
+If you want to save a RAMP model you created with a .py file into a spreadsheet refer to
+this `example <https://rampdemand.readthedocs.io/en/latest/examples/using_excel/using_excel.html#exporting-the-database>`_
 
 For other examples of command lines options, such as setting date ranges, please visit `the dedicated section  <https://rampdemand.readthedocs.io/en/latest/examples/year_simulation/year_simulation.html#setting-date-range>`_ of the documentation.
 

--- a/README.rst
+++ b/README.rst
@@ -194,11 +194,12 @@ Other options are documented in the help of `ramp`, which you access with the ``
 
 
 If you have existing python input files, you can convert them to
-spreadsheet. To do so, go to the ``\ramp`` folder and run
+spreadsheet. Simply run
 
 .. code-block:: bash
 
-   python ramp_convert_old_input_files.py -i <path to the input file you wish to convert>
+   ramp_convert -i <path to the input file you wish to convert>
+
 
 For other examples of command lines options, such as setting date ranges, please visit `the dedicated section  <https://rampdemand.readthedocs.io/en/latest/examples/year_simulation/year_simulation.html#setting-date-range>`_ of the documentation.
 

--- a/docs/notebooks/fixed_flat_app.ipynb
+++ b/docs/notebooks/fixed_flat_app.ipynb
@@ -95,16 +95,6 @@
      "text": [
       "You will simulate 7 day(s) from 2023-01-01 00:00:00 until 2023-01-08 00:00:00\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\users\\tahavorm\\downloads\\gitrepos\\ramp\\ramp\\core\\core.py:299: FutureWarning: 'T' is deprecated and will be removed in a future version. Please use 'min' instead of 'T'.\n",
-      "  end=self.days[-1] + pd.Timedelta(1, \"d\") - pd.Timedelta(1, \"T\"),\n",
-      "c:\\users\\tahavorm\\downloads\\gitrepos\\ramp\\ramp\\core\\core.py:297: FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.\n",
-      "  self.__datetimeindex = pd.date_range(\n"
-     ]
     }
    ],
    "source": [

--- a/docs/source/api_references.rst
+++ b/docs/source/api_references.rst
@@ -76,6 +76,7 @@ Utilities
 
     load_data
     download_example
+    ramp_py2xlsx
 
 
 *************

--- a/docs/source/examples/fixed_flat_app/fixed_flat_app.rst
+++ b/docs/source/examples/fixed_flat_app/fixed_flat_app.rst
@@ -70,14 +70,6 @@ number of days for generating the profiles:
     You will simulate 7 day(s) from 2023-01-01 00:00:00 until 2023-01-08 00:00:00
 
 
-.. parsed-literal::
-
-    c:\users\tahavorm\downloads\gitrepos\ramp\ramp\core\core.py:299: FutureWarning: 'T' is deprecated and will be removed in a future version. Please use 'min' instead of 'T'.
-      end=self.days[-1] + pd.Timedelta(1, "d") - pd.Timedelta(1, "T"),
-    c:\users\tahavorm\downloads\gitrepos\ramp\ramp\core\core.py:297: FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.
-      self.__datetimeindex = pd.date_range(
-
-
 .. code:: ipython3
 
     fixed_flat = school_case.generate_daily_load_profiles()

--- a/ramp/__init__.py
+++ b/ramp/__init__.py
@@ -18,7 +18,9 @@ from ramp.core.core import UseCase, User, Appliance
 from ramp.core.utils import yearly_pattern, get_day_type
 from ramp.example.examples import load_data, download_example
 from ramp.post_process.post_process import Plot
-from ramp.ramp_convert_old_input_files import convert_old_user_input_file as ramp_py2xlsx
+from ramp.ramp_convert_old_input_files import (
+    convert_old_user_input_file as ramp_py2xlsx,
+)
 
 __authors__ = "Listed in AUTHORS"
 __copyright__ = (

--- a/ramp/__init__.py
+++ b/ramp/__init__.py
@@ -18,6 +18,7 @@ from ramp.core.core import UseCase, User, Appliance
 from ramp.core.utils import yearly_pattern, get_day_type
 from ramp.example.examples import load_data, download_example
 from ramp.post_process.post_process import Plot
+from ramp.ramp_convert_old_input_files import convert_old_user_input_file as ramp_py2xlsx
 
 __authors__ = "Listed in AUTHORS"
 __copyright__ = (

--- a/ramp/cli.py
+++ b/ramp/cli.py
@@ -202,7 +202,7 @@ def main():
             series_frame = pd.DataFrame(
                 np.hstack(year_profile),
                 index=pd.date_range(
-                    start=f"{year}-1-1", end=f"{year}-12-31 23:59", freq="T"
+                    start=f"{year}-1-1", end=f"{year}-12-31 23:59", freq="min"
                 ),
             )
             # Save to minute and hour resolution
@@ -222,9 +222,9 @@ def main():
             )
             resampled = pd.DataFrame()
 
-            resampled["mean"] = series_frame.resample("H").mean()
-            resampled["max"] = series_frame.resample("H").max()
-            resampled["min"] = series_frame.resample("H").min()
+            resampled["mean"] = series_frame.resample("h").mean()
+            resampled["max"] = series_frame.resample("h").max()
+            resampled["min"] = series_frame.resample("h").min()
             # TODO add more columns with other resampled functions (do this in Jupyter)
             resampled.to_csv(
                 os.path.join(ofname, "yearly_profile_hourly_resolution.csv")

--- a/ramp/cli.py
+++ b/ramp/cli.py
@@ -11,7 +11,7 @@ BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 parser = argparse.ArgumentParser(
     prog="ramp",
     description="Execute RAMP code",
-    epilog="To convert '.py' input files into '.xlsx' input files use the command 'ramp_convert'"
+    epilog="To convert '.py' input files into '.xlsx' input files use the command 'ramp_convert'",
 )
 parser.add_argument(
     "-i",

--- a/ramp/cli.py
+++ b/ramp/cli.py
@@ -9,7 +9,9 @@ from ramp.ramp_run import run_usecase
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 parser = argparse.ArgumentParser(
-    prog="python ramp_run.py", description="Execute RAMP code"
+    prog="ramp",
+    description="Execute RAMP code",
+    epilog="To convert '.py' input files into '.xlsx' input files use the command 'ramp_convert'"
 )
 parser.add_argument(
     "-i",

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -8,7 +8,7 @@ from ramp.core.core import UseCase
 
 parser = argparse.ArgumentParser(
     prog="python ramp_convert_old_input_files.py",
-    description="Convert old python input files to xlsx ones",
+    description="Convert RAMP python input files to xlsx ones",
 )
 parser.add_argument(
     "-i",
@@ -88,7 +88,7 @@ def convert_old_user_input_file(
     UseCase(users=user_list).save(output_fname)
 
 
-if __name__ == "__main__":
+def cli():
     args = vars(parser.parse_args())
     fname = args["fname_path"]
     output_path = args.get("output_path")
@@ -105,3 +105,6 @@ if __name__ == "__main__":
                 )
         else:
             convert_old_user_input_file(fname, output_path=output_path, suffix=suffix)
+
+if __name__ == "__main__":
+    cli()

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -82,7 +82,7 @@ def convert_old_user_input_file(
     output_fname = os.path.join(output_path, output_fname)
 
     if os.name != "posix":
-        sys.path.insert(0, os.path.abspath(fname_path))
+        sys.path.insert(0, os.path.dirname(os.path.abspath(fname_path)))
     file_module = importlib.import_module(fname)
 
     user_list = file_module.User_list

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -7,7 +7,7 @@ import argparse
 from ramp.core.core import UseCase
 
 parser = argparse.ArgumentParser(
-    prog="python ramp_convert_old_input_files.py",
+    prog="ramp_convert",
     description="Convert RAMP python input files to xlsx ones",
 )
 parser.add_argument(

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -81,6 +81,8 @@ def convert_old_user_input_file(
     output_fname = fname_path.split(os.path.sep)[-1].replace(".py", suffix)
     output_fname = os.path.join(output_path, output_fname)
 
+    if os.name != "posix":
+        sys.path.insert(0, os.path.abspath(fname_path))
     file_module = importlib.import_module(fname)
 
     user_list = file_module.User_list

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -7,8 +7,7 @@ import argparse
 from ramp.core.core import UseCase
 
 parser = argparse.ArgumentParser(
-    prog="ramp_convert",
-    description="Convert RAMP python input files to xlsx ones",
+    prog="ramp_convert", description="Convert RAMP python input files to xlsx ones"
 )
 parser.add_argument(
     "-i",
@@ -18,10 +17,7 @@ parser.add_argument(
     help="path to the input file (including filename)",
 )
 parser.add_argument(
-    "-o",
-    dest="output_path",
-    type=str,
-    help="path where to save the converted filename",
+    "-o", dest="output_path", type=str, help="path where to save the converted filename"
 )
 parser.add_argument(
     "--suffix",
@@ -44,8 +40,25 @@ for i, a in local_var_names:
 def convert_old_user_input_file(
     fname_path, output_path=None, suffix="", keep_names=True
 ):
-    """
-    Imports an input file from a path and returns a processed User_list
+    """Convert old RAMP python input files to xlsx ones
+
+    The old (RAMP version < 0.5) .py input files defined all users and gathered them in a variable named User_list,
+    this variable must be defined in the .py file to be converted to .xlsx.
+
+    To convert a .py input file to an .xlsx using the UseCase objects, please refer to
+    https://rampdemand.readthedocs.io/en/latest/examples/using_excel/using_excel.html#exporting-the-database
+
+    Parameters
+    ----------
+    fname_path: path
+        path to a .py ramp input file containing a variable named User_list
+    output_path: path, optional
+        path to the converted .xlsx ramp input file, by default the same folder as the .py file
+    suffix: str, optional
+        suffix to be added to the converted .xlsx ramp input file name, default ''
+    keep_names: bool, optional
+        keep the variable names of the Appliance instances as their 'name' attribute, default True
+
     """
 
     line_to_change = -1

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -108,5 +108,6 @@ def cli():
         else:
             convert_old_user_input_file(fname, output_path=output_path, suffix=suffix)
 
+
 if __name__ == "__main__":
     cli()

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     entry_points={
         "console_scripts": [
             "ramp=ramp.cli:main",
+            "ramp_convert=ramp.ramp_convert_old_input_files:cli",
         ],
     },
 )

--- a/tests/test_input_file_conversion.py
+++ b/tests/test_input_file_conversion.py
@@ -69,6 +69,19 @@ class TestConversion:
                 if old_user != new_user:
                     pytest.fail()
 
+    def test_convert_py_to_xlsx_command_line(self):
+        """Convert the 3 example .py input files to xlsx and compare each appliance of each user"""
+        for i, j in enumerate(self.input_files_to_run):
+            old_user_list = load_py_usecase(j=j)
+            output_path = os.path.join("ramp", "test")
+            os.system(
+                f"ramp_convert -i {self.py_fnames[i]} -o {output_path} --suffix {self.file_suffix}"
+            )
+            new_user_list = load_xlsx_usecase(fname=self.xlsx_fnames[i])
+            for old_user, new_user in zip(old_user_list, new_user_list):
+                if old_user != new_user:
+                    pytest.fail()
+
 
 def test_define_appliance_window_directly_equivalent_to_use_windows_method():
     user = User("test user", 1)


### PR DESCRIPTION
This should fix #130 

On linux it works. @Stevogallo - could you try on windows?

In a new virtual env, install this ramp version by checking  out this branch and then form the root of the repository you type `pip install -e .`

To test if it works I suggest you move then within your terminal to a different folder where you copy-paste a `.py` file, then you should be able to convert it to excel using in the command line
`ramp_convert -i <name of your .py ramp input file>`  

Alternatively, you should be able to do it from within a python script: 

```
from ramp import ramp_py2xlsx

ramp_py2xlsx(fname_path="<name of your .py ramp input file>")
```