### PR TITLE
Fix/empty peak time range

### DIFF
--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -356,11 +356,12 @@ class UseCase:
                 sigma=1 / 3 * (peak_window[-1] - peak_window[0]),
             )
         )
-        rand_peak_enlarge = round(
+        # Rand_peak_enlarge is rounded to be at least 1 -> if rounded to 0 peak_time_range would be empty
+        rand_peak_enlarge = max(round(
             math.fabs(
                 peak_time - random.gauss(mu=peak_time, sigma=peak_enlarge * peak_time)
             )
-        )
+        ), 1)
         # The peak_time is randomly enlarged based on the calibration parameter peak_enlarge
         return np.arange(peak_time - rand_peak_enlarge, peak_time + rand_peak_enlarge)
 


### PR DESCRIPTION
Implemented the fix as discussed in issue https://github.com/RAMP-project/RAMP/issues/80.
`rand_peak_enlarge` is always rounded to at least 1 to avoid the empty `peak_time_range` error.