### PR TITLE
Unify contributing guidelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,16 +279,7 @@ Contributing
 ============
 This project is open-source. Interested users are therefore invited to test, comment or contribute to the tool. Submitting issues is the best way to get in touch with the development team, which will address your comment, question, or development request in the best possible way. We are also looking for contributors to the main code, willing to contribute to its capabilities, computational-efficiency, formulation, etc.
 
-To contribute changes:
-
-#. Fork the project on GitHub
-#. Create a feature branch (e.g. named "add-this-new-feature") to work on in your fork
-#. Add your name to the `AUTHORS <https://github.com/RAMP-project/RAMP/blob/development/AUTHORS>`_ file
-#. Commit your changes to the feature branch
-#. Push the branch to GitHub
-#. On GitHub, create a new pull request from the feature branch
-
-When committing new changes, please also take care of checking code stability by means of the `qualitative testing <https://github.com/RAMP-project/RAMP/blob/development/CONTRIBUTING.md>`_ functionality.
+To contribute changes please consult our `Contribution guidelines <https://github.com/RAMP-project/RAMP/blob/main/CONTRIBUTING.md>`_
 
 
 How to cite

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,18 @@ def copy_readme():
         fp.writelines(data)
 
 
+def copy_contributing():
+    with open("../../CONTRIBUTING.md", "r", encoding="utf8") as fp:
+        data = fp.readlines()
+
+    # Change the title of the file
+    data[0] = "# Contribute\n"
+    with open("contributing.md", "w") as fp:
+        fp.writelines(data)
+
+
 copy_readme()
+copy_contributing()
 # -- Project information -----------------------------------------------------
 
 project = "RAMP"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,24 @@ sys.path.insert(0, os.path.abspath("../../.."))
 from notebooks_convert import update_notebooks_rst_files
 
 update_notebooks_rst_files()
+
+
+def copy_readme():
+    with open("../../README.rst", "r", encoding="utf8") as fp:
+        data = fp.readlines()
+
+    # Replace the reference to contributing guidelines with an internal link
+    idx = data.index(
+        "To contribute changes please consult our `Contribution guidelines <https://github.com/RAMP-project/RAMP/blob/main/CONTRIBUTING.md>`_\n"
+    )
+    data[
+        idx
+    ] = "To contribute changes please consult our `Contribution guidelines <contributing.html>`_\n"
+    with open("readme.rst", "w") as fp:
+        fp.writelines(data)
+
+
+copy_readme()
 # -- Project information -----------------------------------------------------
 
 project = "RAMP"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ User Guide:
    algorithm
    examples
    input_parameters
+   contributing
    api_references
 
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -3,5 +3,5 @@
 RAMP Introduction
 *****************
 
-.. include:: ../../README.rst
+.. include:: readme.rst
 


### PR DESCRIPTION
This PR should be rebased and merged after #137 as it builts upon it.

The readme file is copied to the docs folder instead of being linked from the root of the repository, this way we can modify the link to the contribution guidelines to points towards the dedicated section rendered within RTD. 

Because the new theme Wagtail allows a mix and match of .md and .rst we could simply add the Contributing guidelines to the documentation form the CONTRIBUTING.md file a the root of the repository :) 