### PR TITLE
Update README.rst to clarify 'active development'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,5 +310,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 
 .. note::
-
-   This project is under active development!
+   This project is actively maintained and developed. This means that while we provide stable and reliable software releases, we keep developing new features and improvements for upcoming, upgraded versions    of the software.


### PR DESCRIPTION
This PR addresses a comment by a JOSS reviewer that the statement about 'active development' at the bottom of the README may lead to misunderstandings.

The statement is now more explicit and clear.